### PR TITLE
ヘッダー画像の用意(AWS s3に保存)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,6 @@ module.exports = {
     STATIC_FORMS_ACCESS_KEY: process.env.STATIC_FORMS_ACCESS_KEY,
   },
   images: {
-    domains: ['is5-ssl.mzstatic.com','is4-ssl.mzstatic.com','is1-ssl.mzstatic.com','is2-ssl.mzstatic.com'],
+    domains: ['is5-ssl.mzstatic.com','is4-ssl.mzstatic.com','is1-ssl.mzstatic.com','is2-ssl.mzstatic.com','mark-saito-next-blog.s3-ap-northeast-1.amazonaws.com'],
 },
 };

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -35,13 +35,24 @@ export default function Layout({
       <header>
         {home && (
           <>
-            {/* <Image
+            <Image
               priority
-              src="/images/img_home.png"
-              height={600}
+              src="https://mark-saito-next-blog.s3-ap-northeast-1.amazonaws.com/hp-top-header.png"
+              height={800}
               width={1600}
-              alt={'トップページの画像'}
-            /> */}
+              alt={'トップページのヘッダー画像'}
+            />
+          </>
+        )}
+        {!home && (
+          <>
+            <Image
+              priority
+              src="https://mark-saito-next-blog.s3-ap-northeast-1.amazonaws.com/hp-sub-header2.png"
+              height={400}
+              width={1600}
+              alt={'ヘッダー画像'}
+            />
           </>
         )}
       </header>

--- a/src/components/organizms/top/header.tsx
+++ b/src/components/organizms/top/header.tsx
@@ -27,7 +27,7 @@ export default function Header() {
       <HeaderItems>
         <Link href="/hp/app-list">
           <HeaderItem>
-            制作アプリ一覧
+            アプリ一覧
               </HeaderItem>
         </Link>
         <Link href="/posts/">


### PR DESCRIPTION
close #28 

prepare hp header image and storaged in AWS s3